### PR TITLE
fix: update i18next dependency to satisfy peer requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "i18next": "^23.10.1",
+    "i18next": "^25.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.3.1"


### PR DESCRIPTION
## Summary
- bump i18next to the minimum version required by react-i18next to resolve npm install conflicts

## Testing
- npm install *(fails: 403 Forbidden fetching @types/react from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d300d3215c8322b792320699c24edc