### PR TITLE
Configure Vite to use port 4687

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Asumiendo que el código se encuentra en /opt/cex-p2p, para ejecutar la aplicaci
 
 ```bash
 npm run build
-npm run preview -- --host 0.0.0.0 --port 4173
+npm run preview -- --host 0.0.0.0 --port 4687
 ```
 
 Una vez que confirmes que todo funciona, crea el archivo de servicio. Por ejemplo:
@@ -75,7 +75,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/ruta/a/ScolMarkets
-ExecStart=/usr/bin/npm run preview -- --host 0.0.0.0 --port 4173
+ExecStart=/usr/bin/npm run preview -- --host 0.0.0.0 --port 4687
 Restart=always
 Environment=NODE_ENV=production
 User=www-data

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,10 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 4687,
+  },
+  preview: {
+    port: 4687,
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite's dev and preview servers to run on port 4687
- align the README systemd instructions with the new port setting

## Testing
- npm run dev -- --host 0.0.0.0 --port 4687 *(fails: vite: not found due to missing dependencies in the execution environment)*
- npm run preview -- --host 0.0.0.0 --port 4687 *(fails: vite: not found due to missing dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d303f643308322b97fe4941e7fcfa3