### PR TITLE
Refresh theme with light mode default and toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,7 @@
   display: flex;
   flex-direction: column;
   gap: 48px;
+  color: var(--text-primary);
 }
 
 .app__header {
@@ -14,10 +15,10 @@
   justify-content: space-between;
   gap: 24px;
   padding: 32px;
-  border-radius: 24px;
-  background: linear-gradient(140deg, rgba(15, 26, 56, 0.9), rgba(22, 38, 82, 0.78));
-  border: 1px solid rgba(81, 132, 255, 0.25);
-  box-shadow: 0 24px 60px rgba(5, 14, 42, 0.45);
+  border-radius: 28px;
+  background: var(--header-background);
+  border: 1px solid var(--header-border);
+  box-shadow: var(--header-shadow);
   position: relative;
   overflow: hidden;
 }
@@ -26,7 +27,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(67, 132, 255, 0.25), transparent 55%);
+  background: var(--header-highlight);
   pointer-events: none;
 }
 
@@ -35,7 +36,7 @@
   letter-spacing: 0.45em;
   font-size: 0.75rem;
   font-weight: 600;
-  color: rgba(161, 196, 255, 0.7);
+  color: var(--text-muted);
   margin-bottom: 12px;
 }
 
@@ -43,44 +44,89 @@
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 700;
-  color: #ffffff;
+  color: var(--text-primary);
 }
 
 .app__subtitle {
   margin-top: 12px;
   font-size: 1rem;
-  color: rgba(215, 229, 255, 0.78);
+  color: var(--text-soft);
   max-width: 540px;
+}
+
+.app__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: stretch;
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.app__theme-toggle {
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 999px;
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  box-shadow: var(--control-shadow);
+}
+
+.app__theme-button {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app__theme-button:hover,
+.app__theme-button:focus-visible {
+  background: var(--control-hover);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.app__theme-button.is-active {
+  background: var(--accent-gradient);
+  color: var(--accent-contrast);
+  box-shadow: var(--accent-shadow);
 }
 
 .app__language {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-width: 180px;
+  min-width: 200px;
 }
 
 .app__language-label {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  color: rgba(161, 196, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .app__language-select {
   appearance: none;
-  border: 1px solid rgba(81, 132, 255, 0.3);
-  background: rgba(14, 24, 56, 0.85);
-  color: #ffffff;
+  border: 1px solid var(--control-border);
+  background: var(--control-bg);
+  color: var(--text-primary);
   font-size: 0.95rem;
   padding: 10px 14px;
   border-radius: 12px;
   outline: none;
-  box-shadow: 0 12px 30px rgba(28, 66, 135, 0.35);
+  box-shadow: var(--control-shadow);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.app__language-select:focus {
-  border-color: rgba(137, 196, 255, 0.75);
+.app__language-select:focus-visible {
+  border-color: var(--control-focus);
+  box-shadow: var(--control-shadow), 0 0 0 4px var(--focus-ring);
 }
 
 .app__stats {
@@ -90,38 +136,38 @@
 }
 
 .app__stat {
-  background: linear-gradient(150deg, rgba(13, 22, 48, 0.85), rgba(17, 35, 74, 0.7));
-  border: 1px solid rgba(81, 132, 255, 0.18);
+  background: var(--stat-background);
+  border: 1px solid var(--stat-border);
   border-radius: 20px;
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 0 18px 40px rgba(5, 15, 40, 0.45);
+  box-shadow: var(--stat-shadow);
 }
 
 .app__stat--disclaimer {
   grid-column: 1 / -1;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(207, 223, 255, 0.75);
+  background: var(--disclaimer-background);
+  color: var(--disclaimer-text);
 }
 
 .app__stat-value {
   font-size: 1.6rem;
   font-weight: 700;
-  color: #ffffff;
+  color: var(--text-primary);
 }
 
 .app__stat-label {
   font-size: 0.95rem;
-  color: rgba(207, 223, 255, 0.75);
+  color: var(--text-soft);
 }
 
 .app__footer {
   text-align: center;
   padding: 16px 0 24px;
   font-size: 0.85rem;
-  color: rgba(155, 186, 255, 0.7);
+  color: var(--text-muted);
 }
 
 @media (max-width: 720px) {
@@ -134,11 +180,31 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 560px) {
+  .app__controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .app__theme-toggle,
   .app__language {
     width: 100%;
   }
 
+  .app__theme-toggle {
+    justify-content: space-between;
+  }
+
+  .app__theme-button {
+    flex: 1;
+  }
+
+  .app__language {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 480px) {
   .app__language-select {
     width: 100%;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { networkName, platformName } from './config/environment.ts';
 import { tokens } from './config/tokens.ts';
@@ -16,8 +16,24 @@ const languageOptions = [
   { code: 'de', label: 'Deutsch' },
 ];
 
+const THEME_STORAGE_KEY = 'scolmarkets-theme';
+
+const getPreferredTheme = (): 'light' | 'dark' => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
 function App() {
   const { t, i18n } = useTranslation();
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => getPreferredTheme());
   const lastUpdated = useMemo(() => new Date(), []);
   const formattedUpdate = useMemo(
     () =>
@@ -28,6 +44,16 @@ function App() {
     [i18n.language, lastUpdated],
   );
 
+  useEffect(() => {
+    document.documentElement.classList.remove('theme-light', 'theme-dark');
+    document.documentElement.classList.add(`theme-${theme}`);
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const handleThemeChange = (value: 'light' | 'dark') => {
+    setTheme(value);
+  };
+
   return (
     <div className="app">
       <header className="app__header">
@@ -36,22 +62,41 @@ function App() {
           <h1 className="app__title">{t('title', { platform: platformName })}</h1>
           <p className="app__subtitle">{t('subtitle', { network: networkName })}</p>
         </div>
-        <div className="app__language">
-          <label className="app__language-label" htmlFor="language-select">
-            {t('languageLabel')}
-          </label>
-          <select
-            id="language-select"
-            className="app__language-select"
-            value={i18n.language}
-            onChange={(event) => i18n.changeLanguage(event.target.value)}
-          >
-            {languageOptions.map((option) => (
-              <option key={option.code} value={option.code}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+        <div className="app__controls">
+          <div className="app__theme-toggle" role="group" aria-label="Theme selection">
+            <button
+              type="button"
+              className={`app__theme-button ${theme === 'light' ? 'is-active' : ''}`}
+              onClick={() => handleThemeChange('light')}
+            >
+              Light
+            </button>
+            <button
+              type="button"
+              className={`app__theme-button ${theme === 'dark' ? 'is-active' : ''}`}
+              onClick={() => handleThemeChange('dark')}
+            >
+              Dark
+            </button>
+          </div>
+
+          <div className="app__language">
+            <label className="app__language-label" htmlFor="language-select">
+              {t('languageLabel')}
+            </label>
+            <select
+              id="language-select"
+              className="app__language-select"
+              value={i18n.language}
+              onChange={(event) => i18n.changeLanguage(event.target.value)}
+            >
+              {languageOptions.map((option) => (
+                <option key={option.code} value={option.code}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </header>
 

--- a/src/components/TokenTable.css
+++ b/src/components/TokenTable.css
@@ -1,15 +1,17 @@
 .token-table__container {
   overflow-x: auto;
   border-radius: 16px;
-  background: rgba(9, 16, 34, 0.45);
-  box-shadow: 0 20px 45px rgba(5, 15, 40, 0.35);
-  border: 1px solid rgba(81, 132, 255, 0.2);
+  background: var(--table-container-bg);
+  box-shadow: var(--table-shadow);
+  border: 1px solid var(--table-border);
+  backdrop-filter: blur(6px);
 }
 
 .token-table {
   width: 100%;
   border-collapse: collapse;
   min-width: 720px;
+  color: var(--text-primary);
 }
 
 .token-table th,
@@ -23,18 +25,18 @@
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
-  background: rgba(16, 27, 58, 0.9);
-  border-bottom: 1px solid rgba(81, 132, 255, 0.2);
+  color: var(--table-header-text);
+  background: var(--table-header-bg);
+  border-bottom: 1px solid var(--table-border);
 }
 
 .token-table tbody tr {
-  border-bottom: 1px solid rgba(81, 132, 255, 0.12);
+  border-bottom: 1px solid var(--table-row-border);
   transition: background 0.2s ease;
 }
 
 .token-table tbody tr:hover {
-  background: rgba(43, 70, 126, 0.24);
+  background: var(--table-row-hover);
 }
 
 .token-table__asset {
@@ -47,10 +49,10 @@
   width: 44px;
   height: 44px;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--logo-background);
   padding: 6px;
   object-fit: contain;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px var(--logo-border);
 }
 
 .token-table__asset-title {
@@ -63,7 +65,7 @@
 
 .token-table__asset-name {
   font-weight: 600;
-  color: #ffffff;
+  color: var(--text-primary);
   font-size: 1rem;
 }
 
@@ -71,12 +73,12 @@
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.58);
+  color: var(--table-text-secondary);
 }
 
 .token-table__badge {
-  background: linear-gradient(135deg, #2ce2ff, #6c52ff);
-  color: #050d28;
+  background: var(--badge-bg);
+  color: var(--badge-text);
   font-size: 0.65rem;
   font-weight: 700;
   padding: 4px 10px;
@@ -87,7 +89,7 @@
 
 .token-table__description {
   margin: 0;
-  color: rgba(255, 255, 255, 0.64);
+  color: var(--description-color);
   font-size: 0.85rem;
   max-width: 480px;
 }
@@ -103,13 +105,13 @@
 }
 
 .token-table__change.positive {
-  background: rgba(0, 232, 162, 0.14);
-  color: #00e8a2;
+  background: var(--positive-bg);
+  color: var(--positive-text);
 }
 
 .token-table__change.negative {
-  background: rgba(255, 94, 129, 0.14);
-  color: #ff5e81;
+  background: var(--negative-bg);
+  color: var(--negative-text);
 }
 
 .token-table__website-cell {
@@ -121,28 +123,28 @@
 }
 
 .token-table__link {
-  background: linear-gradient(135deg, rgba(70, 92, 255, 0.85), rgba(105, 213, 255, 0.85));
-  color: #050d28;
+  background: var(--link-bg);
+  color: var(--link-text);
   font-weight: 600;
   padding: 10px 16px;
   border-radius: 999px;
   text-decoration: none;
   display: inline-flex;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 25px rgba(54, 125, 255, 0.35);
+  box-shadow: var(--link-shadow);
 }
 
 .token-table__link:hover {
   transform: translateY(-2px);
-  box-shadow: 0 16px 36px rgba(54, 125, 255, 0.45);
+  box-shadow: var(--link-shadow-hover);
 }
 
 .token-table__empty {
   padding: 32px;
   border-radius: 16px;
-  background: rgba(9, 16, 34, 0.65);
-  border: 1px solid rgba(81, 132, 255, 0.2);
-  color: rgba(255, 255, 255, 0.72);
+  background: var(--empty-bg);
+  border: 1px solid var(--table-border);
+  color: var(--empty-text);
   text-align: center;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,140 @@
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap');
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
   font-family: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(180deg, #fff8f0 0%, #ffffff 55%, #f5f5f7 100%);
+  color: #1f2933;
+
+  --text-primary: #1f2933;
+  --text-muted: #6b7280;
+  --text-soft: #7b8794;
+
+  --accent-gradient: linear-gradient(135deg, #ff8a3d, #ff5f17);
+  --accent-contrast: #3d1600;
+  --accent-shadow: 0 12px 28px rgba(255, 138, 61, 0.25);
+
+  --header-background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.96) 0%,
+    rgba(255, 232, 207, 0.92) 100%
+  );
+  --header-border: rgba(255, 173, 94, 0.35);
+  --header-shadow: 0 24px 48px rgba(255, 138, 61, 0.18);
+  --header-highlight: radial-gradient(circle at top right, rgba(255, 163, 102, 0.28), transparent 55%);
+
+  --control-bg: rgba(255, 255, 255, 0.9);
+  --control-border: rgba(255, 173, 94, 0.28);
+  --control-shadow: 0 12px 30px rgba(255, 138, 61, 0.16);
+  --control-hover: rgba(255, 138, 61, 0.12);
+  --control-focus: rgba(255, 138, 61, 0.45);
+  --focus-ring: rgba(255, 138, 61, 0.18);
+
+  --stat-background: linear-gradient(140deg, rgba(255, 255, 255, 0.96), rgba(255, 239, 224, 0.9));
+  --stat-border: rgba(255, 173, 94, 0.24);
+  --stat-shadow: 0 20px 45px rgba(255, 138, 61, 0.15);
+
+  --disclaimer-background: rgba(255, 173, 94, 0.12);
+  --disclaimer-text: #8a4212;
+
+  --table-container-bg: rgba(255, 255, 255, 0.95);
+  --table-border: rgba(255, 173, 94, 0.24);
+  --table-shadow: 0 20px 50px rgba(209, 118, 40, 0.18);
+  --table-header-bg: linear-gradient(135deg, rgba(255, 243, 231, 0.95), rgba(255, 224, 196, 0.9));
+  --table-header-text: #a24b12;
+  --table-row-border: rgba(255, 173, 94, 0.18);
+  --table-row-hover: rgba(255, 163, 102, 0.12);
+  --table-text-secondary: #94603a;
+  --logo-background: rgba(255, 232, 207, 0.7);
+  --logo-border: rgba(255, 182, 115, 0.6);
+  --description-color: #6b7280;
+
+  --badge-bg: linear-gradient(135deg, #ffe6a3, #ff8a3d);
+  --badge-text: #6b3700;
+
+  --positive-bg: rgba(22, 163, 74, 0.12);
+  --positive-text: #166534;
+  --negative-bg: rgba(220, 38, 38, 0.12);
+  --negative-text: #b91c1c;
+
+  --link-bg: linear-gradient(135deg, #ff8a3d, #ffb347);
+  --link-text: #5d2a00;
+  --link-shadow: 0 10px 25px rgba(255, 138, 61, 0.22);
+  --link-shadow-hover: 0 16px 36px rgba(255, 138, 61, 0.28);
+
+  --empty-bg: rgba(255, 255, 255, 0.95);
+  --empty-text: #5f6c7b;
+
+  --selection-bg: rgba(255, 138, 61, 0.2);
+}
+
+.theme-light {
+  color-scheme: light;
+  background: linear-gradient(180deg, #fff8f0 0%, #ffffff 55%, #f5f5f7 100%);
+  color: #1f2933;
+}
+
+.theme-dark {
+  color-scheme: dark;
   background: radial-gradient(circle at top left, #223b82 0%, #060b1b 55%, #030511 100%);
   color: #f5f7ff;
+
+  --text-primary: #ffffff;
+  --text-muted: rgba(161, 196, 255, 0.7);
+  --text-soft: rgba(207, 223, 255, 0.75);
+
+  --accent-gradient: linear-gradient(135deg, #5c7cff, #8bb4ff);
+  --accent-contrast: #050d28;
+  --accent-shadow: 0 12px 28px rgba(67, 132, 255, 0.32);
+
+  --header-background: linear-gradient(140deg, rgba(15, 26, 56, 0.9), rgba(22, 38, 82, 0.78));
+  --header-border: rgba(81, 132, 255, 0.25);
+  --header-shadow: 0 24px 60px rgba(5, 14, 42, 0.45);
+  --header-highlight: radial-gradient(circle at top right, rgba(67, 132, 255, 0.25), transparent 55%);
+
+  --control-bg: rgba(14, 24, 56, 0.85);
+  --control-border: rgba(81, 132, 255, 0.3);
+  --control-shadow: 0 12px 30px rgba(28, 66, 135, 0.35);
+  --control-hover: rgba(81, 132, 255, 0.18);
+  --control-focus: rgba(137, 196, 255, 0.75);
+  --focus-ring: rgba(81, 132, 255, 0.18);
+
+  --stat-background: linear-gradient(150deg, rgba(13, 22, 48, 0.85), rgba(17, 35, 74, 0.7));
+  --stat-border: rgba(81, 132, 255, 0.18);
+  --stat-shadow: 0 18px 40px rgba(5, 15, 40, 0.45);
+
+  --disclaimer-background: rgba(255, 255, 255, 0.04);
+  --disclaimer-text: rgba(207, 223, 255, 0.75);
+
+  --table-container-bg: rgba(9, 16, 34, 0.45);
+  --table-border: rgba(81, 132, 255, 0.2);
+  --table-shadow: 0 20px 45px rgba(5, 15, 40, 0.35);
+  --table-header-bg: rgba(16, 27, 58, 0.9);
+  --table-header-text: rgba(255, 255, 255, 0.7);
+  --table-row-border: rgba(81, 132, 255, 0.12);
+  --table-row-hover: rgba(43, 70, 126, 0.24);
+  --table-text-secondary: rgba(255, 255, 255, 0.58);
+  --logo-background: rgba(255, 255, 255, 0.08);
+  --logo-border: rgba(255, 255, 255, 0.08);
+  --description-color: rgba(255, 255, 255, 0.64);
+
+  --badge-bg: linear-gradient(135deg, #2ce2ff, #6c52ff);
+  --badge-text: #050d28;
+
+  --positive-bg: rgba(0, 232, 162, 0.14);
+  --positive-text: #00e8a2;
+  --negative-bg: rgba(255, 94, 129, 0.14);
+  --negative-text: #ff5e81;
+
+  --link-bg: linear-gradient(135deg, rgba(70, 92, 255, 0.85), rgba(105, 213, 255, 0.85));
+  --link-text: #050d28;
+  --link-shadow: 0 10px 25px rgba(54, 125, 255, 0.35);
+  --link-shadow-hover: 0 16px 36px rgba(54, 125, 255, 0.45);
+
+  --empty-bg: rgba(9, 16, 34, 0.65);
+  --empty-text: rgba(255, 255, 255, 0.72);
+
+  --selection-bg: rgba(91, 151, 255, 0.45);
 }
 
 * {
@@ -15,6 +145,7 @@ body {
   margin: 0;
   min-height: 100vh;
   background: transparent;
+  color: inherit;
 }
 
 #root {
@@ -22,5 +153,5 @@ body {
 }
 
 ::selection {
-  background: rgba(91, 151, 255, 0.45);
+  background: var(--selection-bg);
 }


### PR DESCRIPTION
## Summary
- default the experience to a warm light theme that better matches the requested palette
- add a persistent light/dark mode toggle and propagate theme colors with CSS variables
- restyle the token table and layout surfaces to share the new modern light and dark styling

## Testing
- npm run build *(fails: missing vite/client types because packages cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d30d14b4108322a1df919177bd9f69