### PR TITLE
Improve loading overlay and token presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/scol-favicon.svg" />
+    <link rel="icon" type="image/png" href="https://scolcoin.com/i/scolcoin-icon-180.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ScolMarkets</title>
   </head>

--- a/src/App.css
+++ b/src/App.css
@@ -129,12 +129,6 @@
   box-shadow: var(--control-shadow), 0 0 0 4px var(--focus-ring);
 }
 
-.app__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 24px;
-}
-
 .app__status {
   margin-bottom: 16px;
   padding: 12px 16px;
@@ -156,21 +150,75 @@
   color: rgba(255, 204, 209, 0.95);
 }
 
+.app__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
 .app__stat {
   background: var(--stat-background);
   border: 1px solid var(--stat-border);
-  border-radius: 20px;
+  border-radius: 22px;
   padding: 24px;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 18px;
   box-shadow: var(--stat-shadow);
+  position: relative;
+  overflow: hidden;
 }
 
-.app__stat--disclaimer {
+.app__stat::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, transparent 55%, rgba(255, 255, 255, 0.08));
+  pointer-events: none;
+}
+
+.app__stat--wide {
   grid-column: 1 / -1;
   background: var(--disclaimer-background);
   color: var(--disclaimer-text);
+}
+
+.app__stat--wide .app__stat-value {
+  color: inherit;
+}
+
+.app__stat--wide .app__stat-icon {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: transparent;
+  box-shadow: none;
+  color: inherit;
+}
+
+.app__stat-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: var(--stat-icon-bg);
+  border: 1px solid var(--stat-icon-border);
+  box-shadow: var(--stat-icon-shadow);
+  color: var(--accent-contrast);
+  flex-shrink: 0;
+}
+
+.app__stat-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.app__stat-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  z-index: 1;
 }
 
 .app__stat-value {
@@ -182,6 +230,15 @@
 .app__stat-label {
   font-size: 0.95rem;
   color: var(--text-soft);
+  letter-spacing: 0.02em;
+}
+
+.app__stat-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: inherit;
+  opacity: 0.92;
+  line-height: 1.5;
 }
 
 .app__footer {
@@ -189,6 +246,58 @@
   padding: 16px 0 24px;
   font-size: 0.85rem;
   color: var(--text-muted);
+}
+
+.app__overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  backdrop-filter: blur(4px);
+}
+
+.app__overlay-card {
+  background: var(--overlay-card-bg);
+  border: 1px solid var(--overlay-card-border);
+  border-radius: 24px;
+  padding: 32px 36px;
+  max-width: 420px;
+  width: calc(100% - 48px);
+  text-align: center;
+  box-shadow: 0 24px 60px rgba(5, 12, 32, 0.45);
+  color: var(--overlay-text);
+}
+
+.app__overlay-spinner {
+  width: 54px;
+  height: 54px;
+  margin: 0 auto 20px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.25);
+  border-top-color: rgba(255, 255, 255, 0.85);
+  animation: app-spin 1s linear infinite;
+}
+
+.app__overlay-title {
+  margin: 0 0 12px;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.app__overlay-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+@keyframes app-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 720px) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ const getPreferredTheme = (): 'light' | 'dark' => {
 function App() {
   const { t, i18n } = useTranslation();
   const { tokens, isLoading, errorKey, lastUpdated } = useTokensData();
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => getPreferredTheme());
   const tokenCount = tokens.length;
   const fallbackUpdate = t('stats.notAvailable');
 
@@ -48,7 +49,77 @@ function App() {
     [fallbackUpdate, i18n.language, lastUpdated],
   );
 
+  const statCards = useMemo(
+    () => [
+      {
+        key: 'listed',
+        icon: (
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path
+              d="M5 4h14a2 2 0 0 1 2 2v10.5a2 2 0 0 1-2 2H9.5L5 22v-3.5H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z"
+              fill="currentColor"
+              opacity="0.12"
+            />
+            <path
+              d="M7.5 8.5h9M7.5 12h5.5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ),
+        value: new Intl.NumberFormat(i18n.language).format(tokenCount),
+        label: t('stats.listed', { count: tokenCount }),
+      },
+      {
+        key: 'updated',
+        icon: (
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" fill="currentColor" opacity="0.1" />
+            <path
+              d="M12 7v5l3 2"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ),
+        value: formattedUpdate,
+        label: t('stats.lastUpdated'),
+      },
+      {
+        key: 'disclaimer',
+        icon: (
+          <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path
+              d="M12 3.5 3.5 9v6L12 20.5 20.5 15V9L12 3.5Z"
+              fill="currentColor"
+              opacity="0.12"
+            />
+            <path
+              d="M12 10.5v4M12 8.5v.01"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ),
+        value: t('stats.disclaimerTitle'),
+        description: t('stats.disclaimer'),
+        isWide: true,
+      },
+    ],
+    [formattedUpdate, i18n.language, t, tokenCount],
+  );
+
   useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
     document.documentElement.classList.remove('theme-light', 'theme-dark');
     document.documentElement.classList.add(`theme-${theme}`);
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
@@ -105,23 +176,26 @@ function App() {
       </header>
 
       <section className="app__stats">
-        <div className="app__stat">
-          <span className="app__stat-value">{tokenCount}</span>
-          <span className="app__stat-label">{t('stats.listed', { count: tokenCount })}</span>
-        </div>
-        <div className="app__stat">
-          <span className="app__stat-value">{formattedUpdate}</span>
-          <span className="app__stat-label">{t('stats.lastUpdated')}</span>
-        </div>
-        <div className="app__stat app__stat--disclaimer">
-          <span className="app__stat-label">{t('stats.disclaimer')}</span>
-        </div>
+        {statCards.map((stat) => (
+          <article
+            key={stat.key}
+            className={`app__stat ${stat.isWide ? 'app__stat--wide' : ''}`}
+          >
+            <span className="app__stat-icon" aria-hidden="true">
+              {stat.icon}
+            </span>
+            <div className="app__stat-content">
+              <span className="app__stat-value">{stat.value}</span>
+              {stat.label ? <span className="app__stat-label">{stat.label}</span> : null}
+              {stat.description ? (
+                <p className="app__stat-description">{stat.description}</p>
+              ) : null}
+            </div>
+          </article>
+        ))}
       </section>
 
-      <main>
-        {isLoading ? (
-          <p className="app__status app__status--loading">{t('status.loading')}</p>
-        ) : null}
+      <main aria-busy={isLoading} aria-live="polite">
         {errorKey ? (
           <p className="app__status app__status--error">{t(errorKey)}</p>
         ) : null}
@@ -129,6 +203,16 @@ function App() {
       </main>
 
       <footer className="app__footer">{t('footer')}</footer>
+
+      {isLoading ? (
+        <div className="app__overlay" role="status" aria-live="assertive">
+          <div className="app__overlay-card">
+            <div className="app__overlay-spinner" aria-hidden="true" />
+            <h2 className="app__overlay-title">{t('status.processing')}</h2>
+            <p className="app__overlay-description">{t('status.processingDescription')}</p>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/TokenTable.css
+++ b/src/components/TokenTable.css
@@ -134,6 +134,8 @@
   border-radius: 999px;
   text-decoration: none;
   display: inline-flex;
+  align-items: center;
+  gap: 10px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow: var(--link-shadow);
 }
@@ -143,6 +145,21 @@
   box-shadow: var(--link-shadow-hover);
 }
 
+.token-table__link-icon {
+  display: inline-flex;
+}
+
+.token-table__link-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.token-table__link-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .token-table__empty {
   padding: 32px;
   border-radius: 16px;
@@ -150,6 +167,33 @@
   border: 1px solid var(--table-border);
   color: var(--empty-text);
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.token-table__empty-icon {
+  display: inline-flex;
+  width: 64px;
+  height: 64px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 18px;
+  background: var(--logo-background);
+  color: var(--badge-text);
+  box-shadow: inset 0 0 0 1px var(--logo-border);
+}
+
+.token-table__empty-icon svg {
+  width: 48px;
+  height: 48px;
+}
+
+.token-table__empty-text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
 @media (max-width: 960px) {

--- a/src/components/TokenTable.tsx
+++ b/src/components/TokenTable.tsx
@@ -17,7 +17,36 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
     value === null || value === undefined ? '—' : formatCompactNumber(value, locale);
 
   if (!sortedTokens.length) {
-    return <p className="token-table__empty">{t('table.empty')}</p>;
+    return (
+      <div className="token-table__empty" role="status" aria-live="polite">
+        <span className="token-table__empty-icon" aria-hidden="true">
+          <svg viewBox="0 0 48 48" focusable="false">
+            <rect
+              x="6"
+              y="12"
+              width="36"
+              height="26"
+              rx="4"
+              fill="currentColor"
+              opacity="0.08"
+            />
+            <path
+              d="M14 21.5h8M14 28h4.5"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              opacity="0.7"
+            />
+            <path
+              d="M24.5 28H34L30.5 22l-3.5 6Z"
+              fill="currentColor"
+              opacity="0.22"
+            />
+          </svg>
+        </span>
+        <p className="token-table__empty-text">{t('table.empty')}</p>
+      </div>
+    );
   }
 
   return (
@@ -79,7 +108,26 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
                     target="_blank"
                     rel="noreferrer noopener"
                   >
-                    {t('table.visitSite')}
+                    <span className="token-table__link-icon" aria-hidden="true">
+                      <svg viewBox="0 0 20 20" focusable="false">
+                        <path
+                          d="M7.5 12.5 12.5 7.5M8 7.5h4.5V12"
+                          stroke="currentColor"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                        <path
+                          d="M8 4.5H5.75A1.75 1.75 0 0 0 4 6.25v7.5A1.75 1.75 0 0 0 5.75 15.5h7.5a1.75 1.75 0 0 0 1.75-1.75V11"
+                          stroke="currentColor"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          opacity="0.7"
+                        />
+                      </svg>
+                    </span>
+                    <span className="token-table__link-text">{t('table.visitSite')}</span>
                   </a>
                 </td>
               </tr>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,12 +12,15 @@ const resources = {
         updated: 'Data refreshed {{time}}',
         lastUpdated: 'Last update',
         notAvailable: 'Not available',
+        disclaimerTitle: 'Stay informed',
         disclaimer: 'All metrics are illustrative and sourced from the configured environment feed.',
       },
       status: {
         loading: 'Loading on-chain prices…',
         error: 'Unable to update prices from the blockchain. Showing configured values.',
         missingConfig: 'Set the price contract address and RPC endpoint to enable live prices.',
+        processing: 'Processing market data…',
+        processingDescription: 'Please wait while we synchronise the latest token information.',
       },
       table: {
         headers: {
@@ -48,12 +51,15 @@ const resources = {
         updated: 'Datos actualizados {{time}}',
         lastUpdated: 'Última actualización',
         notAvailable: 'No disponible',
+        disclaimerTitle: 'Información importante',
         disclaimer: 'Todos los indicadores son ilustrativos y provienen de la configuración del entorno.',
       },
       status: {
         loading: 'Cargando precios on-chain…',
         error: 'No fue posible actualizar los precios desde la blockchain. Se muestran los valores configurados.',
         missingConfig: 'Configura la dirección del contrato y el nodo RPC para habilitar los precios en vivo.',
+        processing: 'Procesando datos del mercado…',
+        processingDescription: 'Por favor espera mientras sincronizamos la información más reciente de los tokens.',
       },
       table: {
         headers: {
@@ -84,12 +90,15 @@ const resources = {
         updated: 'Données actualisées {{time}}',
         lastUpdated: 'Dernière mise à jour',
         notAvailable: 'Non disponible',
+        disclaimerTitle: 'Informations clés',
         disclaimer: 'Toutes les métriques sont indicatives et proviennent de la configuration de l’environnement.',
       },
       status: {
         loading: 'Chargement des prix on-chain…',
         error: 'Impossible de mettre à jour les prix depuis la blockchain. Affichage des valeurs configurées.',
         missingConfig: 'Configurez l’adresse du contrat et le nœud RPC pour activer les prix en direct.',
+        processing: 'Traitement des données de marché…',
+        processingDescription: 'Veuillez patienter pendant la synchronisation des dernières informations sur les tokens.',
       },
       table: {
         headers: {
@@ -120,12 +129,15 @@ const resources = {
         updated: 'डेटा {{time}} अद्यतन',
         lastUpdated: 'अंतिम अद्यतन',
         notAvailable: 'उपलब्ध नहीं',
+        disclaimerTitle: 'महत्वपूर्ण जानकारी',
         disclaimer: 'सभी आँकड़े उदाहरणार्थ हैं और पर्यावरण विन्यास से प्राप्त होते हैं।',
       },
       status: {
         loading: 'ऑन-चेन मूल्य लोड हो रहे हैं…',
         error: 'ब्लॉकचेन से मूल्य अपडेट नहीं हो सके। कॉन्फ़िगर किए गए मान दिखाए जा रहे हैं।',
         missingConfig: 'लाइव मूल्यों के लिए अनुबंध पता और RPC नोड कॉन्फ़िगर करें।',
+        processing: 'बाज़ार डेटा संसाधित हो रहा है…',
+        processingDescription: 'कृपया प्रतीक्षा करें जब तक हम नवीनतम टोकन जानकारी समन्वयित करते हैं।',
       },
       table: {
         headers: {
@@ -156,12 +168,15 @@ const resources = {
         updated: '数据已于 {{time}} 更新',
         lastUpdated: '最近更新时间',
         notAvailable: '暂无数据',
+        disclaimerTitle: '重要提示',
         disclaimer: '所有指标仅供参考，来源于环境配置的数据。',
       },
       status: {
         loading: '正在加载链上价格…',
         error: '无法从区块链更新价格，显示配置中的数值。',
         missingConfig: '请配置价格合约地址和 RPC 节点以启用实时价格。',
+        processing: '正在处理市场数据…',
+        processingDescription: '请稍候，我们正在同步最新的代币信息。',
       },
       table: {
         headers: {
@@ -192,12 +207,15 @@ const resources = {
         updated: 'Данные обновлены {{time}}',
         lastUpdated: 'Время последнего обновления',
         notAvailable: 'Недоступно',
+        disclaimerTitle: 'Важная информация',
         disclaimer: 'Все показатели являются демонстрационными и поступают из настроек окружения.',
       },
       status: {
         loading: 'Загружаем цены из блокчейна…',
         error: 'Не удалось обновить цены из блокчейна. Показаны настроенные значения.',
         missingConfig: 'Укажите адрес контракта и RPC-узел, чтобы включить актуальные цены.',
+        processing: 'Обрабатываем рыночные данные…',
+        processingDescription: 'Пожалуйста, подождите, мы синхронизируем актуальную информацию о токенах.',
       },
       table: {
         headers: {
@@ -228,12 +246,15 @@ const resources = {
         updated: 'تم تحديث البيانات {{time}}',
         lastUpdated: 'آخر تحديث',
         notAvailable: 'غير متوفر',
+        disclaimerTitle: 'معلومات مهمة',
         disclaimer: 'جميع المؤشرات توضيحية ويتم الحصول عليها من إعدادات بيئة العمل.',
       },
       status: {
         loading: 'جاري تحميل الأسعار من السلسلة…',
         error: 'تعذّر تحديث الأسعار من البلوكشين. يتم عرض القيم المكوّنة.',
         missingConfig: 'يرجى ضبط عنوان العقد ونقطة RPC لتفعيل الأسعار المباشرة.',
+        processing: 'جارٍ معالجة بيانات السوق…',
+        processingDescription: 'يرجى الانتظار بينما نقوم بمزامنة أحدث معلومات الرموز.',
       },
       table: {
         headers: {
@@ -264,12 +285,15 @@ const resources = {
         updated: 'Daten aktualisiert {{time}}',
         lastUpdated: 'Letzte Aktualisierung',
         notAvailable: 'Nicht verfügbar',
+        disclaimerTitle: 'Wichtige Hinweise',
         disclaimer: 'Alle Kennzahlen dienen nur zur Veranschaulichung und stammen aus der Umgebungs-Konfiguration.',
       },
       status: {
         loading: 'On-Chain-Preise werden geladen…',
         error: 'Preise konnten nicht aus der Blockchain aktualisiert werden. Angezeigte Werte stammen aus der Konfiguration.',
         missingConfig: 'Bitte Vertragsadresse und RPC-Endpunkt konfigurieren, um Live-Preise zu aktivieren.',
+        processing: 'Marktdaten werden verarbeitet…',
+        processingDescription: 'Bitte warten, während wir die neuesten Token-Informationen synchronisieren.',
       },
       table: {
         headers: {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@
   --badge-bg: linear-gradient(135deg, #ffe6a3, #ff8a3d);
   --badge-text: #6b3700;
 
+  --stat-icon-bg: rgba(255, 255, 255, 0.92);
+  --stat-icon-border: rgba(255, 173, 94, 0.35);
+  --stat-icon-shadow: 0 12px 32px rgba(255, 138, 61, 0.22);
+
   --positive-bg: rgba(22, 163, 74, 0.12);
   --positive-text: #166534;
   --negative-bg: rgba(220, 38, 38, 0.12);
@@ -66,6 +70,11 @@
   --empty-text: #5f6c7b;
 
   --selection-bg: rgba(255, 138, 61, 0.2);
+
+  --overlay-background: rgba(11, 17, 35, 0.45);
+  --overlay-card-bg: rgba(15, 25, 56, 0.94);
+  --overlay-card-border: rgba(91, 141, 255, 0.35);
+  --overlay-text: rgba(255, 255, 255, 0.92);
 }
 
 .theme-light {
@@ -121,6 +130,10 @@
   --badge-bg: linear-gradient(135deg, #2ce2ff, #6c52ff);
   --badge-text: #050d28;
 
+  --stat-icon-bg: rgba(12, 24, 56, 0.82);
+  --stat-icon-border: rgba(81, 132, 255, 0.3);
+  --stat-icon-shadow: 0 12px 30px rgba(5, 15, 40, 0.45);
+
   --positive-bg: rgba(0, 232, 162, 0.14);
   --positive-text: #00e8a2;
   --negative-bg: rgba(255, 94, 129, 0.14);
@@ -135,6 +148,11 @@
   --empty-text: rgba(255, 255, 255, 0.72);
 
   --selection-bg: rgba(91, 151, 255, 0.45);
+
+  --overlay-background: rgba(2, 6, 18, 0.6);
+  --overlay-card-bg: rgba(5, 12, 28, 0.9);
+  --overlay-card-border: rgba(91, 151, 255, 0.28);
+  --overlay-text: rgba(207, 223, 255, 0.95);
 }
 
 * {


### PR DESCRIPTION
## Summary
- point the site favicon at the hosted Scolcoin icon
- add theme state restoration, modern stat cards, and a full-screen processing overlay while token data loads
- refresh token table interactions with icons and update translations for the new loading copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31655e8f883229b0ffb53646aff0c