### PR TITLE
Fix duplicate theme state declaration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => getPreferredTheme());
   const tokenCount = tokens.length;
   const fallbackUpdate = t('stats.notAvailable');
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => getPreferredTheme());
 
   const formattedUpdate = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- remove the duplicate theme state declaration in `App.tsx`
- keep a single source of truth for the selected theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31a652fe083229409d9ea0701032c