### PR TITLE
Simplify token table columns

### DIFF
--- a/src/components/TokenTable.css
+++ b/src/components/TokenTable.css
@@ -10,8 +10,7 @@
 .token-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 960px;
-
+  min-width: 820px;
 }
 
 .token-table--animated .token-table__row {
@@ -152,26 +151,6 @@
   color: var(--description-color);
   font-size: 0.85rem;
   max-width: 480px;
-}
-
-.token-table__change {
-  font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 96px;
-}
-
-.token-table__change.positive {
-  background: var(--positive-bg);
-  color: var(--positive-text);
-}
-
-.token-table__change.negative {
-  background: var(--negative-bg);
-  color: var(--negative-text);
 }
 
 .token-table__website-cell {

--- a/src/components/TokenTable.tsx
+++ b/src/components/TokenTable.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Token } from '../types/token.ts';
-import { formatCompactNumber, formatCrypto, formatCurrency, formatPercentage } from '../utils/format.ts';
+import { formatCompactNumber, formatCrypto, formatCurrency } from '../utils/format.ts';
 import './TokenTable.css';
 
 type TokenTableProps = {
@@ -149,17 +149,13 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
             <th>{t('table.headers.asset')}</th>
             <th className="token-table__numeric">{t('table.headers.price')}</th>
             <th className="token-table__numeric">{t('table.headers.marketCap')}</th>
-            <th className="token-table__numeric">{t('table.headers.volume24h')}</th>
-            <th className="token-table__numeric">{t('table.headers.change24h')}</th>
             <th className="token-table__numeric">{t('table.headers.totalSupply')}</th>
-            <th className="token-table__numeric">{t('table.headers.maxSupply')}</th>
             <th className="token-table__numeric">{t('table.headers.circulatingSupply')}</th>
             <th className="token-table__website-header">{t('table.headers.website')}</th>
           </tr>
         </thead>
         <tbody>
           {sortedTokens.map((token, index) => {
-            const changeClass = token.change24h >= 0 ? 'positive' : 'negative';
             const rowStyle = { '--row-index': index } as CSSProperties;
             return (
               <tr key={token.symbol} className="token-table__row" style={rowStyle}>
@@ -185,14 +181,7 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
                 </td>
                 <td className="token-table__numeric token-table__price-cell">{renderPrice(token)}</td>
                 <td className="token-table__numeric">{formatCompactNumber(token.marketCap, locale)}</td>
-                <td className="token-table__numeric">{formatCompactNumber(token.volume24h, locale)}</td>
-                <td className="token-table__numeric">
-                  <span className={`token-table__change ${changeClass}`}>
-                    {formatPercentage(token.change24h, locale)}
-                  </span>
-                </td>
                 <td className="token-table__numeric">{formatSupply(token.totalSupply)}</td>
-                <td className="token-table__numeric">{formatSupply(token.maxSupply)}</td>
                 <td className="token-table__numeric">{formatSupply(token.circulatingSupply)}</td>
                 <td className="token-table__website-cell">
                   <a


### PR DESCRIPTION
## Summary
- remove the 24h volume, 24h change, and max supply columns from the token table to shorten each row
- update the table layout styling to reflect the reduced column set

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d31dd59a14832283517a30a67c4dc5