### PR TITLE
Simplify website column icon-only design

### DIFF
--- a/src/components/TokenTable.css
+++ b/src/components/TokenTable.css
@@ -146,13 +146,6 @@
   text-transform: uppercase;
 }
 
-.token-table__description {
-  margin: 0;
-  color: var(--description-color);
-  font-size: 0.85rem;
-  max-width: 480px;
-}
-
 .token-table__website-cell {
   text-align: right;
 }
@@ -165,12 +158,12 @@
   background: var(--link-bg);
   color: var(--link-text);
   font-weight: 600;
-  padding: 10px 16px;
+  padding: 10px;
   border-radius: 999px;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  justify-content: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow: var(--link-shadow);
 }
@@ -187,12 +180,6 @@
 .token-table__link-icon svg {
   width: 18px;
   height: 18px;
-}
-
-.token-table__link-text {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .token-table__empty {

--- a/src/components/TokenTable.tsx
+++ b/src/components/TokenTable.tsx
@@ -175,7 +175,6 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
                           <span className="token-table__badge">{t('table.nativeBadge')}</span>
                         ) : null}
                       </div>
-                      <p className="token-table__description">{token.description}</p>
                     </div>
                   </div>
                 </td>
@@ -189,6 +188,8 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
                     href={token.website}
                     target="_blank"
                     rel="noreferrer noopener"
+                    aria-label={t('table.visitSite')}
+                    title={t('table.visitSite')}
                   >
                     <span className="token-table__link-icon" aria-hidden="true">
                       <svg viewBox="0 0 20 20" focusable="false">
@@ -209,7 +210,6 @@ export const TokenTable = ({ tokens, locale }: TokenTableProps) => {
                         />
                       </svg>
                     </span>
-                    <span className="token-table__link-text">{t('table.visitSite')}</span>
                   </a>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- remove token descriptions from each token table row
- replace the website link text with an icon-only control that keeps localized labelling
- tweak the website link styling to center the standalone icon

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d320851910832280bf964fcd2f6821