### PR TITLE
Stop fetching RPC prices on main overview

### DIFF
--- a/src/hooks/useTokensData.ts
+++ b/src/hooks/useTokensData.ts
@@ -1,8 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
-import { priceContractAddress, rpcUrl } from '../config/environment.ts';
+import { useMemo } from 'react';
 import { getConfiguredTokens, sortTokens } from '../config/tokens.ts';
 import type { Token } from '../types/token.ts';
-import { fetchOnChainPrice } from '../services/priceClient.ts';
 
 type UseTokensDataResult = {
   tokens: Token[];
@@ -12,90 +10,12 @@ type UseTokensDataResult = {
 };
 
 export const useTokensData = (): UseTokensDataResult => {
-  const baseTokens = useMemo(() => getConfiguredTokens(), []);
-  const [tokens, setTokens] = useState<Token[]>(baseTokens);
-  const [isLoading, setIsLoading] = useState<boolean>(baseTokens.length > 0);
-  const [errorKey, setErrorKey] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-
-  useEffect(() => {
-    if (!baseTokens.length) {
-      setIsLoading(false);
-      return;
-    }
-
-    if (!priceContractAddress || !rpcUrl) {
-      setErrorKey('status.missingConfig');
-      setIsLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-
-    const refresh = async () => {
-      setIsLoading(true);
-      let encounteredError = false;
-
-      try {
-        const updatedTokens = await Promise.all(
-          baseTokens.map(async (token) => {
-            const lookupKey = (token.priceId ?? token.name).trim();
-            if (!lookupKey) {
-              return token;
-            }
-
-            try {
-              const priceData = await fetchOnChainPrice(lookupKey);
-              if (!priceData || !priceData.status) {
-                return token;
-              }
-
-              return {
-                ...token,
-                price: priceData.usd,
-                priceData,
-              };
-            } catch (error) {
-              console.warn(`Failed to fetch on-chain price for ${token.name}`, error);
-              encounteredError = true;
-              return token;
-            }
-          }),
-        );
-
-        if (cancelled) {
-          return;
-        }
-
-        setTokens(sortTokens(updatedTokens));
-        setLastUpdated(new Date());
-        setErrorKey(encounteredError ? 'status.error' : null);
-      } catch (error) {
-        console.error('Unable to refresh token prices from the blockchain', error);
-        if (cancelled) {
-          return;
-        }
-
-        setTokens(baseTokens);
-        setErrorKey('status.error');
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    refresh();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [baseTokens, priceContractAddress, rpcUrl]);
+  const tokens = useMemo(() => sortTokens(getConfiguredTokens()), []);
 
   return {
     tokens,
-    isLoading,
-    errorKey,
-    lastUpdated,
+    isLoading: false,
+    errorKey: null,
+    lastUpdated: null,
   };
 };


### PR DESCRIPTION
## Summary
- stop loading on-chain prices in the overview hook
- rely on configured token data so the blockchain error banner never appears

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d323d06dc08322b41ea64c5cf7975d