### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -302,11 +302,34 @@
 
 @media (max-width: 720px) {
   .app {
-    padding: 48px 20px 32px;
+    padding: 40px 20px 28px;
+    gap: 36px;
   }
 
   .app__header {
-    padding: 24px;
+    padding: 22px;
+    gap: 20px;
+  }
+
+  .app__subtitle {
+    font-size: 0.95rem;
+  }
+
+  .app__stats {
+    gap: 20px;
+  }
+
+  .app__stat {
+    padding: 20px;
+  }
+
+  .app__stat-icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .app__stat-value {
+    font-size: 1.4rem;
   }
 }
 
@@ -335,6 +358,32 @@
 }
 
 @media (max-width: 480px) {
+  .app {
+    padding: 32px 16px 24px;
+  }
+
+  .app__header {
+    padding: 20px;
+  }
+
+  .app__title {
+    font-size: clamp(1.6rem, 8vw, 2.2rem);
+  }
+
+  .app__stat {
+    padding: 18px;
+    gap: 12px;
+  }
+
+  .app__stat-icon {
+    width: 44px;
+    height: 44px;
+  }
+
+  .app__stat-value {
+    font-size: 1.3rem;
+  }
+
   .app__language-select {
     width: 100%;
   }

--- a/src/components/TokenTable.css
+++ b/src/components/TokenTable.css
@@ -242,10 +242,77 @@
   }
 }
 
-@media (max-width: 680px) {
-  .token-table__asset {
+@media (max-width: 768px) {
+  .token-table__container {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    overflow-x: visible;
+    padding: 0;
+  }
+
+  .token-table {
+    min-width: 0;
+    display: block;
+  }
+
+  .token-table thead {
+    display: none;
+  }
+
+  .token-table tbody {
+    display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    gap: 16px;
+    padding: 16px 0;
+  }
+
+  .token-table tbody tr {
+    display: grid;
+    gap: 16px;
+    border-bottom: none;
+    padding: 20px;
+    border-radius: 18px;
+    border: 1px solid var(--table-border);
+    background: var(--table-container-bg);
+    box-shadow: var(--table-shadow);
+  }
+
+  .token-table__row--interactive:focus-visible {
+    outline-offset: 0;
+  }
+
+  .token-table__cell {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .token-table__cell::before {
+    content: attr(data-label);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--table-text-secondary);
+  }
+
+  .token-table__cell--asset {
+    gap: 16px;
+  }
+
+  .token-table__cell--asset::before {
+    margin-bottom: 4px;
+  }
+
+  .token-table__asset {
+    align-items: center;
+    gap: 14px;
+  }
+
+  .token-table__asset-title {
+    gap: 8px;
   }
 
   .token-table__logo {
@@ -253,12 +320,19 @@
     height: 40px;
   }
 
-  .token-table__website-cell,
-  .token-table__website-header {
+  .token-table__numeric {
     text-align: left;
   }
 
-  .token-table__link {
+  .token-table__price {
+    align-items: flex-start;
+  }
+
+  .token-table__website-cell {
+    align-items: stretch;
+  }
+
+  .token-table__website-cell .token-table__link {
     width: 100%;
     justify-content: center;
   }

--- a/src/components/TokenTable.tsx
+++ b/src/components/TokenTable.tsx
@@ -15,6 +15,18 @@ export const TokenTable = ({ tokens, locale, onTokenSelect }: TokenTableProps) =
   const [hasAnimated, setHasAnimated] = useState(false);
   const detailsLabel = t('table.openDetails', 'View details');
 
+  const headerLabels = useMemo(
+    () => ({
+      asset: t('table.headers.asset'),
+      price: t('table.headers.price'),
+      marketCap: t('table.headers.marketCap'),
+      totalSupply: t('table.headers.totalSupply'),
+      circulatingSupply: t('table.headers.circulatingSupply'),
+      website: t('table.headers.website'),
+    }),
+    [t],
+  );
+
   const sortedTokens = useMemo(() => tokens, [tokens]);
   useEffect(() => {
     if (!sortedTokens.length) {
@@ -167,12 +179,12 @@ export const TokenTable = ({ tokens, locale, onTokenSelect }: TokenTableProps) =
       <table className={`token-table${hasAnimated ? ' token-table--animated' : ''}`}>
         <thead>
           <tr>
-            <th>{t('table.headers.asset')}</th>
-            <th className="token-table__numeric">{t('table.headers.price')}</th>
-            <th className="token-table__numeric">{t('table.headers.marketCap')}</th>
-            <th className="token-table__numeric">{t('table.headers.totalSupply')}</th>
-            <th className="token-table__numeric">{t('table.headers.circulatingSupply')}</th>
-            <th className="token-table__website-header">{t('table.headers.website')}</th>
+            <th>{headerLabels.asset}</th>
+            <th className="token-table__numeric">{headerLabels.price}</th>
+            <th className="token-table__numeric">{headerLabels.marketCap}</th>
+            <th className="token-table__numeric">{headerLabels.totalSupply}</th>
+            <th className="token-table__numeric">{headerLabels.circulatingSupply}</th>
+            <th className="token-table__website-header">{headerLabels.website}</th>
           </tr>
         </thead>
         <tbody>
@@ -191,7 +203,10 @@ export const TokenTable = ({ tokens, locale, onTokenSelect }: TokenTableProps) =
                 aria-label={interactive ? `${detailsLabel}: ${token.name}` : undefined}
                 title={interactive ? detailsLabel : undefined}
               >
-                <td>
+                <td
+                  className="token-table__cell token-table__cell--asset"
+                  data-label={headerLabels.asset}
+                >
                   <div className="token-table__asset">
                     <img
                       src={token.logo}
@@ -210,11 +225,34 @@ export const TokenTable = ({ tokens, locale, onTokenSelect }: TokenTableProps) =
                     </div>
                   </div>
                 </td>
-                <td className="token-table__numeric token-table__price-cell">{renderPrice(token)}</td>
-                <td className="token-table__numeric">{formatCompactNumber(token.marketCap, locale)}</td>
-                <td className="token-table__numeric">{formatSupply(token.totalSupply)}</td>
-                <td className="token-table__numeric">{formatSupply(token.circulatingSupply)}</td>
-                <td className="token-table__website-cell">
+                <td
+                  className="token-table__cell token-table__numeric token-table__price-cell"
+                  data-label={headerLabels.price}
+                >
+                  {renderPrice(token)}
+                </td>
+                <td
+                  className="token-table__cell token-table__numeric"
+                  data-label={headerLabels.marketCap}
+                >
+                  {formatCompactNumber(token.marketCap, locale)}
+                </td>
+                <td
+                  className="token-table__cell token-table__numeric"
+                  data-label={headerLabels.totalSupply}
+                >
+                  {formatSupply(token.totalSupply)}
+                </td>
+                <td
+                  className="token-table__cell token-table__numeric"
+                  data-label={headerLabels.circulatingSupply}
+                >
+                  {formatSupply(token.circulatingSupply)}
+                </td>
+                <td
+                  className="token-table__cell token-table__website-cell"
+                  data-label={headerLabels.website}
+                >
                   <a
                     className="token-table__link"
                     href={token.website}


### PR DESCRIPTION
## Summary
- adapt the token table to display as stacked cards on smaller viewports with translated labels
- tune mobile styling for token cards, stats, and header spacing for a friendlier handheld layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d32ef1f60c8322bc6e58b289471343