### PR TITLE
Fix on-chain price selector for precios lookup

### DIFF
--- a/src/services/priceClient.ts
+++ b/src/services/priceClient.ts
@@ -1,7 +1,7 @@
 import { priceContractAddress, rpcUrls } from '../config/environment.ts';
 import type { TokenPrice } from '../types/price.ts';
 
-const PRECIOS_SELECTOR = '0x1002aa9d';
+const PRECIOS_SELECTOR = '0x2a18cda2';
 const DECIMALS = 10n;
 const WORD_SIZE = 64;
 const ADDRESS_LENGTH = 40;


### PR DESCRIPTION
## Summary
- update the ABI selector used to query the `precios(string)` mapping so JSON-RPC calls return live oracle data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d347d607f88322b145a6574a356e8e