### PR TITLE
Highlight SCOL native currency in token details

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -51,6 +51,12 @@ const resources = {
         website: 'Official website',
         openInExplorer: 'Open {{token}} in Scolcoin Explorer',
         visitWebsite: 'Visit official website',
+        nativeHighlightBadge: 'Native currency',
+        nativeHighlightTitle: "The network's native currency",
+        nativeHighlightDescription:
+          'SCOL powers every transaction on Scolcoin. As the base coin it does not rely on a smart-contract address.',
+        accountsExplorer: 'Accounts explorer',
+        openAccountsExplorer: 'Open the Scolcoin accounts explorer',
         pricesUnavailable: 'Live prices will appear once the oracle responds.',
         oracleStatus: {
           online: 'Oracle online',
@@ -122,6 +128,12 @@ const resources = {
         website: 'Sitio web oficial',
         openInExplorer: 'Abrir {{token}} en el explorador de Scolcoin',
         visitWebsite: 'Sitio web oficial',
+        nativeHighlightBadge: 'Moneda nativa',
+        nativeHighlightTitle: 'La moneda nativa de la red',
+        nativeHighlightDescription:
+          'SCOL impulsa cada transacción en Scolcoin. Al ser la moneda base no depende de una dirección de smart contract.',
+        accountsExplorer: 'Explorador de cuentas',
+        openAccountsExplorer: 'Abrir el explorador de cuentas de Scolcoin',
         pricesUnavailable: 'Los precios en vivo aparecerán cuando el oráculo responda.',
         oracleStatus: {
           online: 'Oráculo en línea',
@@ -193,6 +205,12 @@ const resources = {
         website: 'Site officiel',
         openInExplorer: 'Ouvrir dans l’explorateur Scolcoin',
         visitWebsite: 'Site officiel',
+        nativeHighlightBadge: 'Actif natif',
+        nativeHighlightTitle: 'La monnaie native du réseau',
+        nativeHighlightDescription:
+          'SCOL alimente chaque transaction sur Scolcoin. En tant que monnaie de base, elle ne dépend pas d’une adresse de smart contract.',
+        accountsExplorer: 'Explorateur de comptes',
+        openAccountsExplorer: 'Ouvrir l’explorateur de comptes Scolcoin',
         pricesUnavailable: 'Les prix en direct apparaîtront lorsque l’oracle répondra.',
         oracleStatus: {
           online: 'Oracle en ligne',
@@ -264,6 +282,12 @@ const resources = {
         website: 'आधिकारिक वेबसाइट',
         openInExplorer: '{{token}} को Scolcoin एक्सप्लोरर में खोलें',
         visitWebsite: 'आधिकारिक वेबसाइट',
+        nativeHighlightBadge: 'मूल मुद्रा',
+        nativeHighlightTitle: 'नेटवर्क की मूल मुद्रा',
+        nativeHighlightDescription:
+          'SCOL सकोलकॉइन नेटवर्क पर हर लेन-देन को शक्ति देता है। आधार सिक्का होने के कारण इसे स्मार्ट कॉन्ट्रैक्ट पते की आवश्यकता नहीं होती।',
+        accountsExplorer: 'खाता एक्सप्लोरर',
+        openAccountsExplorer: 'Scolcoin खातों का एक्सप्लोरर खोलें',
         pricesUnavailable: 'ओरेकल के उत्तर देने पर लाइव मूल्य दिखाई देंगे.',
         oracleStatus: {
           online: 'ओरेकल ऑनलाइन',
@@ -335,6 +359,12 @@ const resources = {
         website: '官方网站',
         openInExplorer: '在 Scolcoin 浏览器中打开 {{token}}',
         visitWebsite: '官方网站',
+        nativeHighlightBadge: '原生货币',
+        nativeHighlightTitle: '网络的原生货币',
+        nativeHighlightDescription:
+          'SCOL 为 Scolcoin 网络上的每笔交易提供动力，作为基础代币无需智能合约地址。',
+        accountsExplorer: '账户浏览器',
+        openAccountsExplorer: '打开 Scolcoin 账户浏览器',
         pricesUnavailable: '当预言机返回数据时，将显示实时价格。',
         oracleStatus: {
           online: '预言机在线',
@@ -405,6 +435,12 @@ const resources = {
         website: 'Официальный сайт',
         openInExplorer: 'Открыть {{token}} в обозревателе Scolcoin',
         visitWebsite: 'Официальный сайт',
+        nativeHighlightBadge: 'Базовая монета',
+        nativeHighlightTitle: 'Нативная валюта сети',
+        nativeHighlightDescription:
+          'SCOL обеспечивает каждую транзакцию в сети Scolcoin. Как базовая монета, она не привязана к адресу смарт-контракта.',
+        accountsExplorer: 'Обозреватель счетов',
+        openAccountsExplorer: 'Открыть обозреватель счетов Scolcoin',
         pricesUnavailable: 'Онлайн-цены появятся, когда оракул предоставит данные.',
         oracleStatus: {
           online: 'Оракул в сети',
@@ -476,6 +512,12 @@ const resources = {
         website: 'الموقع الرسمي',
         openInExplorer: 'افتح {{token}} في مستكشف Scolcoin',
         visitWebsite: 'الموقع الرسمي',
+        nativeHighlightBadge: 'العملة الأصلية',
+        nativeHighlightTitle: 'العملة الأصلية للشبكة',
+        nativeHighlightDescription:
+          'تدعم SCOL كل معاملة على شبكة Scolcoin، وبصفتها العملة الأساسية فهي لا تعتمد على عنوان عقد ذكي.',
+        accountsExplorer: 'مستكشف الحسابات',
+        openAccountsExplorer: 'افتح مستكشف حسابات Scolcoin',
         pricesUnavailable: 'ستظهر الأسعار المباشرة عند استجابة الأوركل.',
         oracleStatus: {
           online: 'الأوراكل متصل',
@@ -547,6 +589,12 @@ const resources = {
         website: 'Offizielle Website',
         openInExplorer: '{{token}} im Scolcoin-Explorer öffnen',
         visitWebsite: 'Offizielle Website',
+        nativeHighlightBadge: 'Native Währung',
+        nativeHighlightTitle: 'Die native Währung des Netzwerks',
+        nativeHighlightDescription:
+          'SCOL treibt jede Transaktion im Scolcoin-Netzwerk an. Als Basis-Coin benötigt er keine Smart-Contract-Adresse.',
+        accountsExplorer: 'Konten-Explorer',
+        openAccountsExplorer: 'Scolcoin-Konten-Explorer öffnen',
         pricesUnavailable: 'Live-Preise werden angezeigt, sobald das Oracle antwortet.',
         oracleStatus: {
           online: 'Orakel online',

--- a/src/pages/TokenDetails.css
+++ b/src/pages/TokenDetails.css
@@ -177,6 +177,61 @@
   gap: 16px;
 }
 
+.token-details__native-highlight {
+  margin: 0 0 18px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(255, 173, 94, 0.18), rgba(255, 138, 61, 0.08));
+  border: 1px solid rgba(255, 173, 94, 0.32);
+  box-shadow: 0 18px 36px rgba(255, 138, 61, 0.16);
+  display: grid;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.token-details__native-highlight::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.token-details__native-highlight > * {
+  position: relative;
+  z-index: 1;
+}
+
+.token-details__native-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 700;
+  background: var(--badge-bg);
+  color: var(--badge-text);
+  box-shadow: var(--link-shadow);
+}
+
+.token-details__native-title {
+  margin: 0;
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.token-details__native-description {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
 .token-details__metric {
   display: grid;
   gap: 4px;

--- a/src/pages/TokenDetails.tsx
+++ b/src/pages/TokenDetails.tsx
@@ -34,6 +34,8 @@ const shortenAddress = (address: string) => {
 };
 
 const buildExplorerUrl = (address: string) => `https://explorador.scolcoin.com/token/${address}`;
+const nativeAccountsExplorerUrl = 'https://explorador.scolcoin.com/accounts';
+const nativeAccountsExplorerDisplay = nativeAccountsExplorerUrl.replace(/^https?:\/\//, '');
 
 const buildPriceRows = (priceData: TokenPrice | null, token: Token, locale: string) => {
   const sources = [priceData, token.priceData ?? null];
@@ -310,11 +312,20 @@ export const TokenDetails = ({ symbol, onBack }: TokenDetailsProps) => {
         return `${token.change24h >= 0 ? '+' : '-'}${formatted}`;
       })()
     : null;
-  const explorerUrl = useMemo(() => buildExplorerUrl(token.address), [token.address]);
-  const shortenedAddress = useMemo(() => shortenAddress(token.address), [token.address]);
+  const explorerUrl = useMemo(
+    () => (token.isNative ? nativeAccountsExplorerUrl : buildExplorerUrl(token.address)),
+    [token.address, token.isNative],
+  );
+  const explorerDisplay = useMemo(
+    () => (token.isNative ? nativeAccountsExplorerDisplay : shortenAddress(token.address)),
+    [token.address, token.isNative],
+  );
   const explorerLabel = useMemo(
-    () => `${t('details.openInExplorer', { token: token.symbol })}. ${token.address}`,
-    [t, token.address, token.symbol],
+    () =>
+      token.isNative
+        ? t('details.openAccountsExplorer')
+        : `${t('details.openInExplorer', { token: token.symbol })}. ${token.address}`,
+    [t, token.address, token.isNative, token.symbol],
   );
 
   return (
@@ -427,9 +438,16 @@ export const TokenDetails = ({ symbol, onBack }: TokenDetailsProps) => {
 
         <article className="token-details__card">
           <h3>{t('details.contract')}</h3>
+          {token.isNative ? (
+            <div className="token-details__native-highlight">
+              <span className="token-details__native-chip">{t('details.nativeHighlightBadge')}</span>
+              <h4 className="token-details__native-title">{t('details.nativeHighlightTitle')}</h4>
+              <p className="token-details__native-description">{t('details.nativeHighlightDescription')}</p>
+            </div>
+          ) : null}
           <dl className="token-details__metrics">
             <div className="token-details__metric">
-              <dt>{t('details.address')}</dt>
+              <dt>{t(token.isNative ? 'details.accountsExplorer' : 'details.address')}</dt>
               <dd>
                 <a
                   className="token-details__address-link"
@@ -437,9 +455,9 @@ export const TokenDetails = ({ symbol, onBack }: TokenDetailsProps) => {
                   target="_blank"
                   rel="noreferrer noopener"
                   aria-label={explorerLabel}
-                  title={token.address}
+                  title={token.isNative ? explorerUrl : token.address}
                 >
-                  <code className="token-details__address-code">{shortenedAddress}</code>
+                  <code className="token-details__address-code">{explorerDisplay}</code>
                   <span aria-hidden="true" className="token-details__external-icon">
                     <svg viewBox="0 0 16 16" focusable="false">
                       <path


### PR DESCRIPTION
## Summary
- route the SCOL token contract section to the accounts explorer and show a dedicated native currency callout
- style the native callout to stand out within the contract card
- localize the new messaging across all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d34bd8ae488322981775bc9f5c9244