### PR TITLE
Add Scol-specific links to official website section

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -51,6 +51,12 @@ const resources = {
         website: 'Official website',
         openInExplorer: 'Open {{token}} in Scolcoin Explorer',
         visitWebsite: 'Visit official website',
+        websiteLinks: {
+          official: 'Visit official website',
+          price: 'Open price dashboard',
+          wallet: 'Open Scolcoin Wallet',
+          explorer: 'Open Scolcoin Explorer',
+        },
         nativeHighlightBadge: 'Native currency',
         nativeHighlightTitle: "The network's native currency",
         nativeHighlightDescription:
@@ -128,6 +134,12 @@ const resources = {
         website: 'Sitio web oficial',
         openInExplorer: 'Abrir {{token}} en el explorador de Scolcoin',
         visitWebsite: 'Sitio web oficial',
+        websiteLinks: {
+          official: 'Sitio web oficial',
+          price: 'Abrir panel de precios',
+          wallet: 'Abrir la billetera Scolcoin',
+          explorer: 'Abrir el explorador de Scolcoin',
+        },
         nativeHighlightBadge: 'Moneda nativa',
         nativeHighlightTitle: 'La moneda nativa de la red',
         nativeHighlightDescription:
@@ -205,6 +217,12 @@ const resources = {
         website: 'Site officiel',
         openInExplorer: 'Ouvrir dans l’explorateur Scolcoin',
         visitWebsite: 'Site officiel',
+        websiteLinks: {
+          official: 'Visiter le site officiel',
+          price: 'Ouvrir le tableau des prix',
+          wallet: 'Ouvrir le portefeuille Scolcoin',
+          explorer: 'Ouvrir l’explorateur Scolcoin',
+        },
         nativeHighlightBadge: 'Actif natif',
         nativeHighlightTitle: 'La monnaie native du réseau',
         nativeHighlightDescription:
@@ -282,6 +300,12 @@ const resources = {
         website: 'आधिकारिक वेबसाइट',
         openInExplorer: '{{token}} को Scolcoin एक्सप्लोरर में खोलें',
         visitWebsite: 'आधिकारिक वेबसाइट',
+        websiteLinks: {
+          official: 'आधिकारिक वेबसाइट देखें',
+          price: 'मूल्य डैशबोर्ड खोलें',
+          wallet: 'Scolcoin वॉलेट खोलें',
+          explorer: 'Scolcoin एक्सप्लोरर खोलें',
+        },
         nativeHighlightBadge: 'मूल मुद्रा',
         nativeHighlightTitle: 'नेटवर्क की मूल मुद्रा',
         nativeHighlightDescription:
@@ -359,6 +383,12 @@ const resources = {
         website: '官方网站',
         openInExplorer: '在 Scolcoin 浏览器中打开 {{token}}',
         visitWebsite: '官方网站',
+        websiteLinks: {
+          official: '访问官方网站',
+          price: '打开价格面板',
+          wallet: '打开 Scolcoin 钱包',
+          explorer: '打开 Scolcoin 浏览器',
+        },
         nativeHighlightBadge: '原生货币',
         nativeHighlightTitle: '网络的原生货币',
         nativeHighlightDescription:
@@ -435,6 +465,12 @@ const resources = {
         website: 'Официальный сайт',
         openInExplorer: 'Открыть {{token}} в обозревателе Scolcoin',
         visitWebsite: 'Официальный сайт',
+        websiteLinks: {
+          official: 'Открыть официальный сайт',
+          price: 'Открыть панель цен',
+          wallet: 'Открыть кошелёк Scolcoin',
+          explorer: 'Открыть обозреватель Scolcoin',
+        },
         nativeHighlightBadge: 'Базовая монета',
         nativeHighlightTitle: 'Нативная валюта сети',
         nativeHighlightDescription:
@@ -512,6 +548,12 @@ const resources = {
         website: 'الموقع الرسمي',
         openInExplorer: 'افتح {{token}} في مستكشف Scolcoin',
         visitWebsite: 'الموقع الرسمي',
+        websiteLinks: {
+          official: 'زيارة الموقع الرسمي',
+          price: 'فتح لوحة الأسعار',
+          wallet: 'فتح محفظة Scolcoin',
+          explorer: 'فتح مستكشف Scolcoin',
+        },
         nativeHighlightBadge: 'العملة الأصلية',
         nativeHighlightTitle: 'العملة الأصلية للشبكة',
         nativeHighlightDescription:
@@ -589,6 +631,12 @@ const resources = {
         website: 'Offizielle Website',
         openInExplorer: '{{token}} im Scolcoin-Explorer öffnen',
         visitWebsite: 'Offizielle Website',
+        websiteLinks: {
+          official: 'Offizielle Website öffnen',
+          price: 'Preis-Dashboard öffnen',
+          wallet: 'Scolcoin-Wallet öffnen',
+          explorer: 'Scolcoin-Explorer öffnen',
+        },
         nativeHighlightBadge: 'Native Währung',
         nativeHighlightTitle: 'Die native Währung des Netzwerks',
         nativeHighlightDescription:

--- a/src/pages/TokenDetails.css
+++ b/src/pages/TokenDetails.css
@@ -299,6 +299,13 @@
   justify-content: space-between;
 }
 
+.token-details__link-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+}
+
 .token-details__card--prices {
   padding-bottom: 28px;
 }
@@ -380,11 +387,11 @@
 }
 
 .token-details__link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  margin-top: 20px;
-  padding: 10px 18px;
+  gap: 12px;
+  justify-content: flex-start;
+  padding: 12px 16px;
   border-radius: 14px;
   background: var(--link-bg);
   color: var(--link-text);
@@ -392,6 +399,7 @@
   text-decoration: none;
   box-shadow: var(--link-shadow);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
 }
 
 .token-details__link:hover,
@@ -399,6 +407,24 @@
   transform: translateY(-2px);
   box-shadow: var(--link-shadow-hover);
   outline: none;
+}
+
+.token-details__link-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  color: currentColor;
+}
+
+.token-details__link-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.token-details__link-label {
+  flex: 1;
 }
 
 .token-details__about {

--- a/src/pages/TokenDetails.tsx
+++ b/src/pages/TokenDetails.tsx
@@ -17,6 +17,13 @@ type Metric = {
   value: string;
 };
 
+type WebsiteLink = {
+  key: string;
+  href: string;
+  label: string;
+  icon: 'website' | 'price' | 'wallet' | 'explorer';
+};
+
 const formatSupplyValue = (value: Token['totalSupply'], locale: string) =>
   value === null || value === undefined ? '—' : formatCompactNumber(value, locale);
 
@@ -35,7 +42,83 @@ const shortenAddress = (address: string) => {
 
 const buildExplorerUrl = (address: string) => `https://explorador.scolcoin.com/token/${address}`;
 const nativeAccountsExplorerUrl = 'https://explorador.scolcoin.com/accounts';
+const priceDashboardUrl = 'https://price.scolcoin.com/';
+const scolWalletUrl = 'https://wallet.scolcoin.com/';
+const explorerHomepageUrl = 'https://explorador.scolcoin.com/';
 const nativeAccountsExplorerDisplay = nativeAccountsExplorerUrl.replace(/^https?:\/\//, '');
+
+const WebsiteLinkIcon = ({ type }: { type: WebsiteLink['icon'] }) => {
+  switch (type) {
+    case 'website':
+      return (
+        <svg viewBox="0 0 24 24" focusable="false">
+          <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <path
+            d="M3.5 12h17M12 3c2.2 2.3 3.5 5.5 3.5 9s-1.3 6.7-3.5 9c-2.2-2.3-3.5-5.5-3.5-9S9.8 5.3 12 3Z"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case 'price':
+      return (
+        <svg viewBox="0 0 24 24" focusable="false">
+          <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <text
+            x="12"
+            y="16"
+            textAnchor="middle"
+            fontSize="11"
+            fontWeight="700"
+            fontFamily="inherit"
+            fill="currentColor"
+          >
+            $
+          </text>
+        </svg>
+      );
+    case 'wallet':
+      return (
+        <svg viewBox="0 0 24 24" focusable="false">
+          <path
+            d="M3.5 8.5a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-11a2 2 0 0 1-2-2Z"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M18.5 10.5h2a1.8 1.8 0 0 1 0 3.6h-2"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <circle cx="16" cy="12.5" r="1" fill="currentColor" />
+        </svg>
+      );
+    case 'explorer':
+      return (
+        <svg viewBox="0 0 24 24" focusable="false">
+          <circle cx="11" cy="11" r="5.5" fill="none" stroke="currentColor" strokeWidth="1.6" />
+          <path
+            d="m14.5 14.5 5 5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    default:
+      return null;
+  }
+};
 
 const buildPriceRows = (priceData: TokenPrice | null, token: Token, locale: string) => {
   const sources = [priceData, token.priceData ?? null];
@@ -238,6 +321,48 @@ export const TokenDetails = ({ symbol, onBack }: TokenDetailsProps) => {
     () => (token ? buildMarketMetrics(token, locale, lastUpdatedLabel) : []),
     [lastUpdatedLabel, locale, token],
   );
+
+  const websiteLinks = useMemo<WebsiteLink[]>(() => {
+    if (!token) {
+      return [];
+    }
+
+    const links: WebsiteLink[] = [];
+
+    if (token.website) {
+      links.push({
+        key: 'official',
+        href: token.website,
+        label: t('details.websiteLinks.official'),
+        icon: 'website',
+      });
+    }
+
+    if (token.isNative) {
+      links.push(
+        {
+          key: 'price',
+          href: priceDashboardUrl,
+          label: t('details.websiteLinks.price'),
+          icon: 'price',
+        },
+        {
+          key: 'wallet',
+          href: scolWalletUrl,
+          label: t('details.websiteLinks.wallet'),
+          icon: 'wallet',
+        },
+        {
+          key: 'explorer',
+          href: explorerHomepageUrl,
+          label: t('details.websiteLinks.explorer'),
+          icon: 'explorer',
+        },
+      );
+    }
+
+    return links;
+  }, [t, token]);
 
   const supplyMetrics = useMemo(() => {
     if (!token) {
@@ -498,17 +623,25 @@ export const TokenDetails = ({ symbol, onBack }: TokenDetailsProps) => {
             </dl>
           </article>
         ) : null}
-        {token.website ? (
+        {websiteLinks.length > 0 ? (
           <article className="token-details__card token-details__card--website">
             <h3>{t('details.website')}</h3>
-            <a
-              className="token-details__link"
-              href={token.website}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              {t('details.visitWebsite')}
-            </a>
+            <div className="token-details__link-list">
+              {websiteLinks.map((link) => (
+                <a
+                  key={link.key}
+                  className="token-details__link"
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <span aria-hidden="true" className="token-details__link-icon">
+                    <WebsiteLinkIcon type={link.icon} />
+                  </span>
+                  <span className="token-details__link-label">{link.label}</span>
+                </a>
+              ))}
+            </div>
           </article>
         ) : null}
       </section>


### PR DESCRIPTION
## Summary
- add support for multiple external links in the official website card, including price, wallet, and explorer destinations for SCOL
- render icon buttons for each external link and adjust styling for the website card
- localize new link labels across all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3fa41120c8322939aa7320906c61b