### PR TITLE
Use dynamic current year in footer

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,9 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+const currentYear = new Date().getFullYear();
+const footerText = `Scolcoin Copyright © 2018 - ${currentYear}. All rights reserved. Create ♥ by Blockchain Technology S.A.S.`;
+
 const resources = {
   en: {
     translation: {
@@ -129,7 +132,7 @@ const resources = {
           btc: 'Bitcoin',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   es: {
@@ -259,7 +262,7 @@ const resources = {
           btc: 'Bitcoin',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   pt: {
@@ -389,7 +392,7 @@ const resources = {
           btc: 'Bitcoin',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   fr: {
@@ -519,7 +522,7 @@ const resources = {
           btc: 'Bitcoin',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   hi: {
@@ -649,7 +652,7 @@ const resources = {
           btc: 'बिटकॉइन',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   zh: {
@@ -778,7 +781,7 @@ const resources = {
           btc: '比特币',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   ja: {
@@ -908,7 +911,7 @@ const resources = {
           btc: 'ビットコイン',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   ru: {
@@ -1038,7 +1041,7 @@ const resources = {
           btc: 'Биткоин',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   ar: {
@@ -1168,7 +1171,7 @@ const resources = {
           btc: 'بيتكوين',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
   de: {
@@ -1298,7 +1301,7 @@ const resources = {
           btc: 'Bitcoin',
         },
       },
-      footer: 'Scolcoin Copyright © 2018 - 2026. All rights reserved. Create ♥ by Blockchain Technology S.A.S.',
+      footer: footerText,
     },
   },
 };


### PR DESCRIPTION
## Summary
- calculate the current calendar year when building the localized footer text
- reuse the shared footer string across all translations so it stays up to date automatically

## Testing
- npm run build *(fails: Cannot find name 'qrGeneratorBaseUrl' in src/pages/TokenDetails.tsx:735)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d918302c832286c11a64c5cfcf0b