### PR TITLE
Add configurable QR generator base URL

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -36,6 +36,9 @@ const parseNativeCurrency = () => {
 export const chainId = parseChainId();
 export const nativeCurrency = parseNativeCurrency();
 export const blockExplorerUrl = (import.meta.env.VITE_BLOCK_EXPLORER_URL ?? 'https://explorador.scolcoin.com/').trim();
+export const qrGeneratorBaseUrl = (
+  import.meta.env.VITE_QR_GENERATOR_BASE_URL ?? 'https://api.qrserver.com/v1/create-qr-code/'
+).trim();
 
 const defaultRpcUrls = [
   'https://mainnet-rpc.scolcoin.com',

--- a/src/pages/TokenDetails.tsx
+++ b/src/pages/TokenDetails.tsx
@@ -7,6 +7,7 @@ import {
   nativeCurrency,
   networkName,
   platformName,
+  qrGeneratorBaseUrl,
   rpcUrls,
 } from '../config/environment.ts';
 import { useTokenDetails } from '../hooks/useTokensData.ts';


### PR DESCRIPTION
## Summary
- add a configurable QR code generator base URL to the environment configuration with a sensible default
- use the configured base URL in the token details view when building QR code links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5478b4b748322b4bac7d39e620d20